### PR TITLE
Fix bloom_add and bloom_test

### DIFF
--- a/bloom.c
+++ b/bloom.c
@@ -87,7 +87,7 @@ void bloom_add(bloom_t filter, const void *item)
     while (h) {
         unsigned int hash = h->func(item);
         hash %= filter->size;
-        bits[hash >> 3] |= 0x40 >> (hash & 7);
+        bits[hash >> 3] |= 0x80 >> (hash & 7);
         h = h->next;
     }
 }
@@ -99,7 +99,7 @@ bool bloom_test(bloom_t filter, const void *item)
     while (h) {
         unsigned int hash = h->func(item);
         hash %= filter->size;
-        if (!(bits[hash >> 3] & (0x40 >> (hash & 7)))) {
+        if (!(bits[hash >> 3] & (0x80 >> (hash & 7)))) {
             return false;
         }
         h = h->next;


### PR DESCRIPTION
As of 8590b5801dc0dc291244e78a541ccfdcd23320f8, bloom_test sometimes falsely reports that an item isn't in the filter.

## Steps to reproduce:

Search the string `Stigler` in the default dictionary.
in `./test_common`, the command `s` works but `f` doesn't

```shell
$ make
$ ./test_common CPY
CPY mechanism
ternary_tree, loaded 206849 words in 0.145068 sec

Commands:
 a  add word to the tree
 f  find word in tree
 s  search words matching prefix
 d  delete word from the tree
 q  quit, freeing all data


choice: s
find words matching prefix (at least 1 char): Stigler
  Stigler - searched prefix in 0.000004 sec

suggest[0] : Stigler

choice: f
find word in tree: Stigler
  Stigler not found by bloom filter.

choice: a
enter word to add: Stigler
  Stigler - inserted in 0.0000054836 sec. (206850 words in tree)

choice: f
find word in tree: Stigler
  Stigler not found by bloom filter.

choice: ^C
```
## The bug
```0x40 >> (i & 7)``` evaluates to 0 when `i == 7`
```python
>>> sorted([0x40 >> (i & 7) for i in range(8)]) 
[0, 1, 2, 4, 8, 16, 32, 64]
>>> sorted([1 << (i & 7) for i in range(8)])
[1, 2, 4, 8, 16, 32, 64, 128]
>>> sorted([0x80 >> (i & 7) for i in range(8)])
[1, 2, 4, 8, 16, 32, 64, 128]
```
