### PR TITLE
Fix tst_delete_word bug 

### DIFF
--- a/tst.c
+++ b/tst.c
@@ -4,23 +4,25 @@
 #define WRDMAX 128
 #define STKMAX (WRDMAX * 2)
 
-/* This macro is used to replace some repeating pattern for rotate and delete
- * the node on tenary search tree. It will append kid of victim on suitable
- * position, then free
- * victim itself. Note that 'kid' should be victim->lokid or victim->hikid
+/* This macro is used to replace some repeating pattern for rotating and
+ * deleting the node on tenary search tree. It will append kid of victim on
+ * suitable position, then free victim itself. Note that 'kid' should be
+ * victim->lokid or victim->hikid
  */
-#define del_node(parent, victim, root, kid) \
-    do {                                    \
-        if (!parent)                        \
-            *root = kid;                    \
-        else if (victim == parent->lokid)   \
-            parent->lokid = kid;            \
-        else if (victim == parent->hikid)   \
-            parent->hikid = kid;            \
-        else                                \
-            parent->eqkid = kid;            \
-        free(victim);                       \
-        victim = NULL;                      \
+#define del_node(parent, victim, root, kid)   \
+    do {                                      \
+        if (!parent) {                        \
+            *root = kid;                      \
+        } else {                              \
+            if (victim == parent->lokid)      \
+                parent->lokid = kid;          \
+            else if (victim == parent->hikid) \
+                parent->hikid = kid;          \
+            else                              \
+                parent->eqkid = kid;          \
+        }                                     \
+        free(victim);                         \
+        victim = NULL;                        \
     } while (0)
 
 
@@ -119,13 +121,9 @@ static void *tst_del_word(tst_node **root,
             } else /* can't rotate, return, leaving victim->eqkid NULL */
                 return NULL;
         } else if (victim->lokid) { /* only lokid, replace victim with lokid */
-            parent->eqkid = victim->lokid;
-            free(victim);
-            victim = NULL;
+            del_node(parent, victim, root, victim->lokid);
         } else if (victim->hikid) { /* only hikid, replace victim with hikid */
-            parent->eqkid = victim->hikid;
-            free(victim);
-            victim = NULL;
+            del_node(parent, victim, root, victim->hikid);
         } else { /* victim - no children, but parent has other children */
             if (victim == parent->lokid) { /* if parent->lokid - trim */
                 parent->lokid = NULL;

--- a/tst.c
+++ b/tst.c
@@ -4,6 +4,26 @@
 #define WRDMAX 128
 #define STKMAX (WRDMAX * 2)
 
+/* This macro is used to replace some repeating pattern for rotate and delete
+ * the node on tenary search tree. It will append kid of victim on suitable
+ * position, then free
+ * victim itself. Note that 'kid' should be victim->lokid or victim->hikid
+ */
+#define del_node(parent, victim, root, kid) \
+    do {                                    \
+        if (!parent)                        \
+            *root = kid;                    \
+        else if (victim == parent->lokid)   \
+            parent->lokid = kid;            \
+        else if (victim == parent->hikid)   \
+            parent->hikid = kid;            \
+        else                                \
+            parent->eqkid = kid;            \
+        free(victim);                       \
+        victim = NULL;                      \
+    } while (0)
+
+
 /** ternary search tree node. */
 typedef struct tst_node {
     char key;               /* char key for node (null for node with string) */
@@ -91,29 +111,11 @@ static void *tst_del_word(tst_node **root,
                  * rotate victim->lokid to place of victim.
                  */
                 victim->lokid->hikid = victim->hikid;
-                if (!parent)
-                    *root = victim->lokid;
-                else if (victim == parent->lokid)
-                    parent->lokid = victim->lokid;
-                else if (victim == parent->hikid)
-                    parent->hikid = victim->lokid;
-                else
-                    parent->eqkid = victim->lokid;
-                free(victim);
-                victim = NULL;
+                del_node(parent, victim, root, victim->lokid);
             } else if (!victim->hikid->lokid) { /* check for lokid in hi tree */
                 /* opposite rotation */
                 victim->hikid->lokid = victim->lokid;
-                if (!parent)
-                    *root = victim->hikid;
-                else if (victim == parent->lokid)
-                    parent->lokid = victim->hikid;
-                else if (victim == parent->hikid)
-                    parent->hikid = victim->hikid;
-                else
-                    parent->eqkid = victim->hikid;
-                free(victim);
-                victim = NULL;
+                del_node(parent, victim, root, victim->hikid);
             } else /* can't rotate, return, leaving victim->eqkid NULL */
                 return NULL;
         } else if (victim->lokid) { /* only lokid, replace victim with lokid */
@@ -143,58 +145,20 @@ static void *tst_del_word(tst_node **root,
                     /* same checks and rotations as above */
                     if (!victim->lokid->hikid) {
                         victim->lokid->hikid = victim->hikid;
-                        if (!parent)
-                            *root = victim->lokid;
-                        else if (victim == parent->lokid)
-                            parent->lokid = victim->lokid;
-                        else if (victim == parent->hikid)
-                            parent->hikid = victim->lokid;
-                        else
-                            parent->eqkid = victim->lokid;
-                        free(victim);
-                        victim = NULL;
+                        del_node(parent, victim, root, victim->lokid);
                     } else if (!victim->hikid->lokid) {
                         victim->hikid->lokid = victim->lokid;
-                        if (!parent)
-                            *root = victim->hikid;
-                        else if (victim == parent->lokid)
-                            parent->lokid = victim->hikid;
-                        else if (victim == parent->hikid)
-                            parent->hikid = victim->hikid;
-                        else
-                            parent->eqkid = victim->hikid;
-                        free(victim);
-                        victim = NULL;
+                        del_node(parent, victim, root, victim->hikid);
                     } else
                         return NULL;
                 }
                 /* if only lokid, rewire to parent */
                 else if (victim->lokid) {
-                    if (parent) { /* if parent exists, rewire */
-                        if (victim == parent->lokid)
-                            parent->lokid = victim->lokid;
-                        else if (victim == parent->hikid)
-                            parent->hikid = victim->lokid;
-                        else
-                            parent->eqkid = victim->lokid;
-                    } else /* we are new root node, update root */
-                        *root = victim->lokid; /* make last node root */
-                    free(victim);
-                    victim = NULL;
+                    del_node(parent, victim, root, victim->lokid);
                 }
                 /* if only hikid, rewire to parent */
                 else if (victim->hikid) {
-                    if (parent) { /* if parent exists, rewire */
-                        if (victim == parent->lokid)
-                            parent->lokid = victim->hikid;
-                        else if (victim == parent->hikid)
-                            parent->hikid = victim->hikid;
-                        else
-                            parent->eqkid = victim->hikid;
-                    } else /* we are new root node, update root */
-                        *root = victim->hikid; /* make last node root */
-                    free(victim);
-                    victim = NULL;
+                    del_node(parent, victim, root, victim->hikid);
                 }
             }
         }


### PR DESCRIPTION
Hi, there's a bug is found and fix here:
*  If you delete some string in TST, for example, `Gurder` by `d` command, then free all node by `q` command, segmentation fault would happened

This was caused by some mistakes when free node at `tst_del_word`.

