### PR TITLE
Free pointer correctly with refcnt in tst_free_all 

### DIFF
--- a/tst.c
+++ b/tst.c
@@ -400,7 +400,7 @@ void tst_free_all(tst_node *p)
     if (p->key)
         tst_free_all(p->eqkid);
     tst_free_all(p->hikid);
-    if (!p->key)
+    if (!p->key && p->refcnt > 0)
         free(p->eqkid);
     free(p);
 }


### PR DESCRIPTION
We should set string pointer to null after free in case of the double free at the end of `tst_free_all` or `tst_free`.